### PR TITLE
feat: add partners module

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,8 @@
       "^@utils/(.*)$":     "<rootDir>/utils/$1",
       "^@companies/(.*)$": "<rootDir>/companies/$1",
       "^@contacts/(.*)$":  "<rootDir>/contacts/$1",
-      "^@opportunities/(.*)$": "<rootDir>/opportunities/$1"
+      "^@opportunities/(.*)$": "<rootDir>/opportunities/$1",
+      "^@partners/(.*)$": "<rootDir>/partners/$1"
     }
   },
   "engines": {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -25,6 +25,7 @@ import { MailerModule } from './mailer/mailer.module';
 import { CompaniesModule } from './companies/companies.module';
 import { ContactsModule } from './contacts/contacts.module';
 import { OpportunitiesModule } from './opportunities/opportunities.module';
+import { PartnersModule } from './partners/partners.module';
 
 const infrastructureDatabaseModule = TypeOrmModule.forRootAsync({
   useClass: TypeOrmConfigService,
@@ -83,6 +84,7 @@ const infrastructureDatabaseModule = TypeOrmModule.forRootAsync({
     CompaniesModule,
     ContactsModule,
     OpportunitiesModule,
+    PartnersModule,
     HomeModule,
   ],
 })

--- a/src/partners/domain/partner.ts
+++ b/src/partners/domain/partner.ts
@@ -1,0 +1,27 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export enum PartnerType {
+  BANK = 'BANK',
+  INSURER = 'INSURER',
+  FINTECH = 'FINTECH',
+}
+
+export class Partner {
+  @ApiProperty({ type: String, example: 'uuid' })
+  id: string;
+
+  @ApiProperty()
+  name: string;
+
+  @ApiProperty({ enum: PartnerType, enumName: 'PartnerType' })
+  type: PartnerType;
+
+  @ApiProperty({ required: false, type: Object })
+  settings?: Record<string, any>;
+
+  @ApiProperty({ type: Date })
+  createdAt: Date;
+
+  @ApiProperty({ type: Date })
+  updatedAt: Date;
+}

--- a/src/partners/dto/create-partner.dto.ts
+++ b/src/partners/dto/create-partner.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsObject, IsOptional, IsString } from 'class-validator';
+import { PartnerType } from '@partners/domain/partner';
+
+export class CreatePartnerDto {
+  @ApiProperty()
+  @IsString()
+  name: string;
+
+  @ApiProperty({ enum: PartnerType, enumName: 'PartnerType' })
+  @IsEnum(PartnerType)
+  type: PartnerType;
+
+  @ApiProperty({ required: false, type: Object })
+  @IsOptional()
+  @IsObject()
+  settings?: Record<string, any>;
+}

--- a/src/partners/dto/query-partner.dto.ts
+++ b/src/partners/dto/query-partner.dto.ts
@@ -1,0 +1,17 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsNumber, IsOptional } from 'class-validator';
+import { Transform } from 'class-transformer';
+
+export class QueryPartnerDto {
+  @ApiPropertyOptional()
+  @Transform(({ value }) => (value ? Number(value) : 1))
+  @IsNumber()
+  @IsOptional()
+  page?: number;
+
+  @ApiPropertyOptional()
+  @Transform(({ value }) => (value ? Number(value) : 10))
+  @IsNumber()
+  @IsOptional()
+  limit?: number;
+}

--- a/src/partners/dto/update-partner.dto.ts
+++ b/src/partners/dto/update-partner.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreatePartnerDto } from './create-partner.dto';
+
+export class UpdatePartnerDto extends PartialType(CreatePartnerDto) {}

--- a/src/partners/infrastructure/persistence/partner.repository.ts
+++ b/src/partners/infrastructure/persistence/partner.repository.ts
@@ -1,0 +1,22 @@
+import { Partner } from '@partners/domain/partner';
+import { IPaginationOptions } from '@utils/types/pagination-options';
+import { NullableType } from '@utils/types/nullable.type';
+
+export abstract class PartnerRepository {
+  abstract create(
+    data: Omit<Partner, 'id' | 'createdAt' | 'updatedAt'>,
+  ): Promise<Partner>;
+
+  abstract findManyWithPagination(options: {
+    paginationOptions: IPaginationOptions;
+  }): Promise<Partner[]>;
+
+  abstract findById(id: Partner['id']): Promise<NullableType<Partner>>;
+
+  abstract update(
+    id: Partner['id'],
+    payload: Partial<Omit<Partner, 'id' | 'createdAt' | 'updatedAt'>>,
+  ): Promise<Partner | null>;
+
+  abstract remove(id: Partner['id']): Promise<void>;
+}

--- a/src/partners/infrastructure/persistence/relational/entities/partner.entity.ts
+++ b/src/partners/infrastructure/persistence/relational/entities/partner.entity.ts
@@ -1,0 +1,29 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { EntityRelationalHelper } from '@utils/relational-entity-helper';
+
+@Entity({ name: 'partner' })
+export class PartnerEntity extends EntityRelationalHelper {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  name: string;
+
+  @Column({ type: 'varchar' })
+  type: string;
+
+  @Column({ type: 'jsonb', nullable: true })
+  settings?: Record<string, any>;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/partners/infrastructure/persistence/relational/mappers/partner.mapper.ts
+++ b/src/partners/infrastructure/persistence/relational/mappers/partner.mapper.ts
@@ -1,0 +1,24 @@
+import { Partner, PartnerType } from '@partners/domain/partner';
+import { PartnerEntity } from '../entities/partner.entity';
+
+export class PartnerMapper {
+  static toDomain(entity: PartnerEntity): Partner {
+    const domain = new Partner();
+    domain.id = entity.id;
+    domain.name = entity.name;
+    domain.type = entity.type as PartnerType;
+    domain.settings = entity.settings ?? undefined;
+    domain.createdAt = entity.createdAt;
+    domain.updatedAt = entity.updatedAt;
+    return domain;
+  }
+
+  static toPersistence(domain: Partner): PartnerEntity {
+    const entity = new PartnerEntity();
+    if (domain.id) entity.id = domain.id;
+    entity.name = domain.name;
+    entity.type = domain.type;
+    entity.settings = domain.settings;
+    return entity;
+  }
+}

--- a/src/partners/infrastructure/persistence/relational/relational-persistence.module.ts
+++ b/src/partners/infrastructure/persistence/relational/relational-persistence.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { PartnerEntity } from '@partners/infrastructure/persistence/relational/entities/partner.entity';
+import { PartnerRepository } from '@partners/infrastructure/persistence/partner.repository';
+import { PartnersRelationalRepository } from '@partners/infrastructure/persistence/relational/repositories/partner.repository';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([PartnerEntity])],
+  providers: [
+    {
+      provide: PartnerRepository,
+      useClass: PartnersRelationalRepository,
+    },
+  ],
+  exports: [PartnerRepository],
+})
+export class RelationalPartnerPersistenceModule {}

--- a/src/partners/infrastructure/persistence/relational/repositories/partner.repository.ts
+++ b/src/partners/infrastructure/persistence/relational/repositories/partner.repository.ts
@@ -1,0 +1,61 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { PartnerRepository } from '@partners/infrastructure/persistence/partner.repository';
+import { PartnerEntity } from '@partners/infrastructure/persistence/relational/entities/partner.entity';
+import { Partner } from '@partners/domain/partner';
+import { PartnerMapper } from '@partners/infrastructure/persistence/relational/mappers/partner.mapper';
+import { IPaginationOptions } from '@utils/types/pagination-options';
+import { NullableType } from '@utils/types/nullable.type';
+
+@Injectable()
+export class PartnersRelationalRepository implements PartnerRepository {
+  constructor(
+    @InjectRepository(PartnerEntity)
+    private readonly repository: Repository<PartnerEntity>,
+  ) {}
+
+  async create(
+    data: Omit<Partner, 'id' | 'createdAt' | 'updatedAt'>,
+  ): Promise<Partner> {
+    const entity = await this.repository.save(
+      this.repository.create(PartnerMapper.toPersistence(data as Partner)),
+    );
+    return PartnerMapper.toDomain(entity);
+  }
+
+  async findManyWithPagination({
+    paginationOptions,
+  }: {
+    paginationOptions: IPaginationOptions;
+  }): Promise<Partner[]> {
+    const entities = await this.repository.find({
+      skip: (paginationOptions.page - 1) * paginationOptions.limit,
+      take: paginationOptions.limit,
+    });
+    return entities.map((e) => PartnerMapper.toDomain(e));
+  }
+
+  async findById(id: Partner['id']): Promise<NullableType<Partner>> {
+    const entity = await this.repository.findOne({ where: { id } });
+    return entity ? PartnerMapper.toDomain(entity) : null;
+  }
+
+  async update(
+    id: Partner['id'],
+    payload: Partial<Omit<Partner, 'id' | 'createdAt' | 'updatedAt'>>,
+  ): Promise<Partner | null> {
+    const entity = await this.repository.findOne({ where: { id } });
+    if (!entity) return null;
+    const domain = PartnerMapper.toDomain(entity);
+    const updatedDomain: Partner = { ...domain, ...payload } as Partner;
+    const updated = await this.repository.save(
+      this.repository.create(PartnerMapper.toPersistence(updatedDomain)),
+    );
+    return PartnerMapper.toDomain(updated);
+  }
+
+  async remove(id: Partner['id']): Promise<void> {
+    await this.repository.softDelete({ id });
+  }
+}

--- a/src/partners/partners.controller.ts
+++ b/src/partners/partners.controller.ts
@@ -1,0 +1,86 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Post,
+  Put,
+  Query,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiCreatedResponse,
+  ApiOkResponse,
+  ApiParam,
+  ApiTags,
+} from '@nestjs/swagger';
+import { PartnersService } from '@partners/partners.service';
+import { CreatePartnerDto } from '@partners/dto/create-partner.dto';
+import { UpdatePartnerDto } from '@partners/dto/update-partner.dto';
+import { Partner } from '@partners/domain/partner';
+import {
+  InfinityPaginationResponse,
+  InfinityPaginationResponseDto,
+} from '@utils/dto/infinity-pagination-response.dto';
+import { QueryPartnerDto } from '@partners/dto/query-partner.dto';
+import { infinityPagination } from '@utils/infinity-pagination';
+
+@ApiBearerAuth()
+@ApiTags('Partners')
+@Controller({ path: 'partners', version: '1' })
+export class PartnersController {
+  constructor(private readonly service: PartnersService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @ApiCreatedResponse({ type: Partner })
+  create(@Body() dto: CreatePartnerDto): Promise<Partner> {
+    return this.service.create(dto);
+  }
+
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  @ApiOkResponse({ type: InfinityPaginationResponse(Partner) })
+  async findAll(
+    @Query() query: QueryPartnerDto,
+  ): Promise<InfinityPaginationResponseDto<Partner>> {
+    const page = query.page ?? 1;
+    let limit = query.limit ?? 10;
+    if (limit > 50) limit = 50;
+    return infinityPagination(
+      await this.service.findManyWithPagination({
+        paginationOptions: { page, limit },
+      }),
+      { page, limit },
+    );
+  }
+
+  @Get(':id')
+  @HttpCode(HttpStatus.OK)
+  @ApiOkResponse({ type: Partner })
+  @ApiParam({ name: 'id', type: String, required: true })
+  findOne(@Param('id') id: Partner['id']): Promise<Partner | null> {
+    return this.service.findById(id);
+  }
+
+  @Put(':id')
+  @HttpCode(HttpStatus.OK)
+  @ApiOkResponse({ type: Partner })
+  @ApiParam({ name: 'id', type: String, required: true })
+  update(
+    @Param('id') id: Partner['id'],
+    @Body() dto: UpdatePartnerDto,
+  ): Promise<Partner | null> {
+    return this.service.update(id, dto);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiParam({ name: 'id', type: String, required: true })
+  remove(@Param('id') id: Partner['id']): Promise<void> {
+    return this.service.remove(id);
+  }
+}

--- a/src/partners/partners.module.ts
+++ b/src/partners/partners.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { PartnersService } from '@partners/partners.service';
+import { PartnersController } from '@partners/partners.controller';
+import { RelationalPartnerPersistenceModule } from '@partners/infrastructure/persistence/relational/relational-persistence.module';
+
+const infrastructurePersistenceModule = RelationalPartnerPersistenceModule;
+
+@Module({
+  imports: [infrastructurePersistenceModule],
+  controllers: [PartnersController],
+  providers: [PartnersService],
+  exports: [PartnersService, infrastructurePersistenceModule],
+})
+export class PartnersModule {}

--- a/src/partners/partners.service.spec.ts
+++ b/src/partners/partners.service.spec.ts
@@ -1,0 +1,29 @@
+import { PartnersService } from './partners.service';
+import { PartnerRepository } from '@partners/infrastructure/persistence/partner.repository';
+import { CreatePartnerDto } from '@partners/dto/create-partner.dto';
+import { PartnerType } from '@partners/domain/partner';
+
+describe('PartnersService', () => {
+  let service: PartnersService;
+  const repo: jest.Mocked<PartnerRepository> = {
+    create: jest.fn(),
+    findManyWithPagination: jest.fn(),
+    findById: jest.fn(),
+    update: jest.fn(),
+    remove: jest.fn(),
+  } as any;
+
+  beforeEach(() => {
+    service = new PartnersService(repo);
+  });
+
+  it('should create partner', async () => {
+    const dto: CreatePartnerDto = {
+      name: 'Coface',
+      type: PartnerType.INSURER,
+    };
+    repo.create.mockResolvedValue({ id: '1', ...dto } as any);
+    const result = await service.create(dto);
+    expect(result).toEqual({ id: '1', ...dto });
+  });
+});

--- a/src/partners/partners.service.ts
+++ b/src/partners/partners.service.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '@nestjs/common';
+import { PartnerRepository } from '@partners/infrastructure/persistence/partner.repository';
+import { CreatePartnerDto } from '@partners/dto/create-partner.dto';
+import { UpdatePartnerDto } from '@partners/dto/update-partner.dto';
+import { Partner } from '@partners/domain/partner';
+import { IPaginationOptions } from '@utils/types/pagination-options';
+import { NullableType } from '@utils/types/nullable.type';
+
+@Injectable()
+export class PartnersService {
+  constructor(private readonly repository: PartnerRepository) {}
+
+  create(dto: CreatePartnerDto): Promise<Partner> {
+    const payload: Omit<Partner, 'id' | 'createdAt' | 'updatedAt'> = {
+      name: dto.name,
+      type: dto.type,
+      settings: dto.settings,
+    };
+    return this.repository.create(payload);
+  }
+
+  findManyWithPagination(options: {
+    paginationOptions: IPaginationOptions;
+  }): Promise<Partner[]> {
+    return this.repository.findManyWithPagination(options);
+  }
+
+  findById(id: Partner['id']): Promise<NullableType<Partner>> {
+    return this.repository.findById(id);
+  }
+
+  update(id: Partner['id'], dto: UpdatePartnerDto): Promise<Partner | null> {
+    const payload: Partial<Omit<Partner, 'id' | 'createdAt' | 'updatedAt'>> = {
+      ...dto,
+    };
+    return this.repository.update(id, payload);
+  }
+
+  remove(id: Partner['id']): Promise<void> {
+    return this.repository.remove(id);
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
       "@utils/*": ["utils/*"],
       "@companies/*": ["companies/*"],
       "@contacts/*": ["contacts/*"],
-      "@opportunities/*": ["opportunities/*"]
+      "@opportunities/*": ["opportunities/*"],
+      "@partners/*": ["partners/*"]
     },
     "incremental": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary
- add initial partners module with CRUD REST endpoints
- configure tsconfig and jest paths for partners

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68907eb46a6c8322865f4b787aec8b2d